### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI_tests.yml
+++ b/.github/workflows/CI_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nikolay-dementiev/DMAction/security/code-scanning/1](https://github.com/nikolay-dementiev/DMAction/security/code-scanning/1)

To fix the issue, we will add a `permissions` key at the root level of the workflow. This will apply the specified permissions to all jobs in the workflow. Based on the tasks performed in the workflow, the least privileges required are `contents: read` to allow the workflow to access the repository's contents. No write permissions are necessary since the workflow does not modify repository contents or perform other write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
